### PR TITLE
🐛 Fix nohoist windows path backslash issue

### DIFF
--- a/src/get-nohoist.js
+++ b/src/get-nohoist.js
@@ -46,8 +46,8 @@ module.exports = function getNohoist(params = {}) {
     })
     .flat(2)
     .map((nohoistPath) => {
-      if(process.platform == "win32" && libNamesOnly){
-        nohoistPath = nohoistPath.replace(/\\/g,"/");
+      if (process.platform === "win32" && libNamesOnly) {
+        nohoistPath = nohoistPath.replace(/\\/g, "/");
       }
       return libNamesOnly
         ? nohoistPath.substring(

--- a/src/get-nohoist.js
+++ b/src/get-nohoist.js
@@ -46,6 +46,9 @@ module.exports = function getNohoist(params = {}) {
     })
     .flat(2)
     .map((nohoistPath) => {
+      if(process.platform == "win32" && libNamesOnly){
+        nohoistPath = nohoistPath.replace(/\\/g,"/");
+      }
       return libNamesOnly
         ? nohoistPath.substring(
             nohoistPath.lastIndexOf("node_modules/") + `node_modules/`.length,


### PR DESCRIPTION
Hi @mmazzarolo,


> Thanks for the amazing lib.

This PR fixes the incorrect nohoistPath library name due to Windows backslash.  Windows uses **\\** instead of **/** in path names.

Platform: **Windows**

- [x] Well tested and it fixes the issue without introducing any bugs.

Best regards!