### PR TITLE
Update get-workspaces to return OS specific paths

### DIFF
--- a/src/get-workspaces.js
+++ b/src/get-workspaces.js
@@ -17,7 +17,7 @@ module.exports = function getWorkspaces(params = {}) {
     : packageJson.workspaces.packages;
   return workspaceGlobs
     .map((workspaceGlob) => {
-      return glob.sync(path.join(monorepoRoot, `${workspaceGlob}/`));
+      return glob.sync(path.join(monorepoRoot, `${workspaceGlob}/`), { realpath: true });
     })
     .flat();
 };


### PR DESCRIPTION
Due to an error in how node-glob returns paths, a specific option is 
required in order to return paths appropriately for each platform.

See: https://github.com/isaacs/node-glob/issues/419
Fixes: https://github.com/mmazzarolo/react-native-universal-monorepo/issues/12