### PR TITLE
Fix error when nohoist is not defined

### DIFF
--- a/src/get-nohoist.js
+++ b/src/get-nohoist.js
@@ -24,7 +24,7 @@ module.exports = function getNohoist(params = {}) {
     : getWorkspaces({ cwd });
   const monorepoRoot = getMonorepoRoot({ cwd });
   const packageJson = require(path.join(monorepoRoot, "package.json"));
-  const nohoistGlobs = packageJson.workspaces.nohoist;
+  const nohoistGlobs = packageJson.workspaces.nohoist || [];
 
   return nohoistGlobs
     .map((nohoistGlob) =>


### PR DESCRIPTION
Fix an error that occurs when nohoist is not defined as in Yarn 2 or 3 since nohoist is deprecated.