### PR TITLE
Update get-webpack-tools.js

### DIFF
--- a/src/get-webpack-tools.js
+++ b/src/get-webpack-tools.js
@@ -41,7 +41,7 @@ module.exports = function getWebpackTools(params = {}) {
   const workspaces = getWorkspaces({ cwd });
   function enableWorkspacesResolution(webpackConfig) {
     const babelLoader = webpackConfig.module.rules[1].oneOf.find((rule) =>
-      rule.loader.includes("babel-loader")
+      rule.loader && rule.loader.includes("babel-loader")
     );
     babelLoader.include = Array.isArray(babelLoader.include)
       ? babelLoader.include


### PR DESCRIPTION
When I updated react-scripts to the latest version, every time that I started my electron app, I got an error from line 44, at get-webpack-tools.js. I fixed it by adding rule.loader && before rule.loader.includes("babel-loader").