### PR TITLE
Update get-webpack-tools.js

### DIFF
--- a/src/get-webpack-tools.js
+++ b/src/get-webpack-tools.js
@@ -40,7 +40,12 @@ module.exports = function getWebpackTools(params = {}) {
   // Allow importing from external workspaces.
   const workspaces = getWorkspaces({ cwd });
   function enableWorkspacesResolution(webpackConfig) {
-    const babelLoader = webpackConfig.module.rules[1].oneOf.find((rule) =>
+    var targetIndex = 1;
+    if (webpackConfig.module.rules.length == 1) {
+      targetIndex = 0; // CRACO 7 / CRA 5 has only one rule
+    }
+
+    const babelLoader = webpackConfig.module.rules[targetIndex].oneOf.find((rule) =>
       rule.loader && rule.loader.includes("babel-loader")
     );
     babelLoader.include = Array.isArray(babelLoader.include)

--- a/src/get-webpack-tools.js
+++ b/src/get-webpack-tools.js
@@ -40,7 +40,7 @@ module.exports = function getWebpackTools(params = {}) {
   // Allow importing from external workspaces.
   const workspaces = getWorkspaces({ cwd });
   function enableWorkspacesResolution(webpackConfig) {
-    var targetIndex = 1;
+    let targetIndex = 1;
     if (webpackConfig.module.rules.length === 1) {
       targetIndex = 0; // CRACO 7 / CRA 5 has only one rule
     }

--- a/src/get-webpack-tools.js
+++ b/src/get-webpack-tools.js
@@ -41,7 +41,7 @@ module.exports = function getWebpackTools(params = {}) {
   const workspaces = getWorkspaces({ cwd });
   function enableWorkspacesResolution(webpackConfig) {
     var targetIndex = 1;
-    if (webpackConfig.module.rules.length == 1) {
+    if (webpackConfig.module.rules.length === 1) {
       targetIndex = 0; // CRACO 7 / CRA 5 has only one rule
     }
 


### PR DESCRIPTION
Added support for CRACO 7 / CRA 5 webconfig sturcture. CRA5 has only 1 module.rules "oneOf" object.